### PR TITLE
Move consul-backup-gcs in charts repo

### DIFF
--- a/consul-backup-gcs/.helmignore
+++ b/consul-backup-gcs/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/consul-backup-gcs/Chart.yaml
+++ b/consul-backup-gcs/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+appVersion: "0.1.0"
+description: Backup Consul Snapshots to GCS using credentials from Vault
+name: consul-backup-gcs
+version: 0.1.1
+home: https://github.com/basisai/consul-backup-gcs

--- a/consul-backup-gcs/README.md
+++ b/consul-backup-gcs/README.md
@@ -1,0 +1,18 @@
+# Consul Backup
+
+This Helm Chart runs a cron job to backup
+[snapshots](https://www.consul.io/docs/commands/snapshot.html) of Consul and save it to
+GCS.
+
+## Requirements
+
+To use the Helm Chart, you need to have the following:
+
+- A GCS Bucket for backing up to
+- A [Vault](https://www.vaultproject.io/) server setup with a Kubernetes Auth Backend for the
+    Kubernetes pod to authenticate with Vault and a GCS Secrets Engine Roleset configured for
+    the pod to retrieve credentials for GCS.
+- A Consul cluster
+
+You can automate most of this using our
+[Terraform Module](https://github.com/basisai/terraform-modules-gcp/blob/master/modules/consul_backup).

--- a/consul-backup-gcs/templates/_helpers.tpl
+++ b/consul-backup-gcs/templates/_helpers.tpl
@@ -1,0 +1,36 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "consul-backup-gcs.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "consul-backup-gcs.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "consul-backup-gcs.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "vaultAddress" -}}
+{{- required "Vault Address" .Values.vault.address -}}
+{{- end -}}

--- a/consul-backup-gcs/templates/config_map.yaml
+++ b/consul-backup-gcs/templates/config_map.yaml
@@ -1,0 +1,72 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "consul-backup-gcs.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "consul-backup-gcs.name" . }}
+    helm.sh/chart: {{ include "consul-backup-gcs.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- with .Values.labels.configMap }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- if .Values.annotations.configMap }}
+  annotations:
+    {{- with .Values.annotations.configMap }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+data:
+  ansible: |
+    consul_environment:
+      CONSUL_HTTP_ADDR: {{ .Values.consul.address }}
+    gcs_bucket: {{ required "GCS bucket is required" .Values.gcs.bucket }}
+    gcs_prefix: {{ .Values.gcs.prefix }}
+    service_account_key: /gcp/service_account.json
+  consulTemplate: |
+    pid_file = "/pid"
+    kill_signal = "SIGTERM"
+
+    vault {
+      vault_agent_token_file = "/vault/token"
+
+      ssl {
+        enabled = true
+      }
+    }
+
+    template {
+      left_delimiter = "||"
+      right_delimiter = "||"
+
+      contents = <<-EOF
+      ||- with secret "{{ required "GCP secrets backend path is needed" .Values.vault.gcp.path }}" -||
+      ||- .Data.private_key_data | base64Decode -||
+      ||- end -||
+      EOF
+
+      destination = "/gcp/service_account.json"
+      create_dest_dirs = true
+      error_on_missing_key = true
+    }
+  vaultCA: {{ required "Vault CA is required" .Values.vault.ca | quote }}
+  vaultAgent: |
+    pid_file = "/pid"
+    exit_after_auth = true
+
+    auto_auth {
+      method "kubernetes" {
+        mount_path = "auth/{{ required "Auth mount path is needed" .Values.vault.auth.path }}"
+
+        config {
+          role = "{{ required "Vault Auth Role is needed" .Values.vault.auth.role }}"
+          token_path = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+        }
+      }
+
+      sink "file" {
+        config {
+          path = "/vault/token"
+        }
+      }
+    }

--- a/consul-backup-gcs/templates/cron_job.yaml
+++ b/consul-backup-gcs/templates/cron_job.yaml
@@ -1,0 +1,171 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ include "consul-backup-gcs.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "consul-backup-gcs.name" . }}
+    helm.sh/chart: {{ include "consul-backup-gcs.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- with .Values.labels.cronJob }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- if .Values.annotations.cronJob }}
+  annotations:
+    {{- with .Values.annotations.cronJob }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  schedule: {{ .Values.schedule }}
+  concurrencyPolicy: {{ .Values.concurrencyPolicy }}
+  successfulJobsHistoryLimit: {{ .Values.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.failedJobsHistoryLimit }}
+  jobTemplate:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "consul-backup-gcs.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- with .Values.labels.cronJob }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/config_map.yaml") . | sha256sum }}
+        {{- with .Values.annotations.cronJob }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      completions: 1
+      parallelism: 1
+      {{- if .Values.ttlSecondsAfterFinished }}
+      ttlSecondsAfterFinished: {{ .Values.ttlSecondsAfterFinished }}
+      {{- end }}
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: {{ include "consul-backup-gcs.name" . }}
+            app.kubernetes.io/instance: {{ .Release.Name }}
+            {{- with .Values.labels.pods }}
+            {{- toYaml . | nindent 10 }}
+            {{- end }}
+          annotations:
+            {{- with .Values.annotations.pods }}
+            {{- toYaml . | nindent 10 }}
+            {{- end }}
+        spec:
+          serviceAccountName: {{ .Values.serviceAccount }}
+          automountServiceAccountToken: true
+          restartPolicy: OnFailure
+          initContainers:
+            - name: vault-agent
+              image: "{{ .Values.vault.image }}:{{ .Values.vault.tag }}"
+              imagePullPolicy: {{ .Values.vault.pullPolicy }}
+              resources:
+                {{- toYaml .Values.resources.vaultAgent | nindent 16 }}
+              volumeMounts:
+                - name: config
+                  mountPath: /config
+                  readOnly: true
+                - name: vault-token
+                  mountPath: /vault
+              env:
+                - name: VAULT_ADDR
+                  value: {{ include "vaultAddress" . | quote }}
+                - name: VAULT_CAPATH
+                  value: /config/vault_ca.pem
+                - name: VAULT_LOG_LEVEL
+                  value: trace
+                {{- if .Values.vault.env }}
+                {{- toYaml .Values.vault.env | nindent 16 }}
+                {{- end }}
+              command:
+                - /bin/vault
+              args:
+                - agent
+                - -config=/config/vault_agent.hcl
+              resources:
+                {{- toYaml .Values.resources.consulTemplate | nindent 16 }}
+            - name: consul-template
+              image: "{{ .Values.consulTemplate.image }}:{{ .Values.consulTemplate.tag }}"
+              imagePullPolicy: {{ .Values.consulTemplate.pullPolicy }}
+              resources:
+                {{- toYaml .Values.resources.consulTemplate | nindent 16 }}
+              volumeMounts:
+                - name: config
+                  mountPath: /config
+                  readOnly: true
+                - name: vault-token
+                  mountPath: /vault
+                  readOnly: true
+                - name: gcp-service-account
+                  mountPath: /gcp
+              env:
+                - name: VAULT_ADDR
+                  value: {{ include "vaultAddress" . | quote }}
+                - name: VAULT_CAPATH
+                  value: /config/vault_ca.pem
+                {{- if .Values.consulTemplate.env }}
+                {{- toYaml .Values.consulTemplate.env | nindent 16 }}
+                {{- end }}
+              command:
+                - "/bin/consul-template"
+              args:
+                - "-once"
+                - "-config=/config/consul_template.hcl"
+                - "-log-level=debug"
+              resources:
+                {{- toYaml .Values.resources.consulTemplate | nindent 16 }}
+          containers:
+            - name: {{ .Chart.Name }}
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              resources:
+                {{- toYaml .Values.resources.backup | nindent 16 }}
+              volumeMounts:
+                - name: gcp-service-account
+                  mountPath: /gcp
+                - name: config
+                  mountPath: /config
+                  readOnly: true
+              env:
+                - name: GOOGLE_CREDENTIALS
+                  value: /gcp/service_account.json
+                {{- if .Values.env }}
+                {{- toYaml .Values.env | nindent 16 }}
+                {{- end }}
+              args:
+                - "ansible-playbook"
+                - '--inventory'
+                - "localhost,"
+                - '--connection=local'
+                - "--extra-vars=@/config/vars.yml"
+                - site.yml
+          volumes:
+            - name: config
+              configMap:
+                name: {{ include "consul-backup-gcs.fullname" . }}
+                items:
+                  - key: vaultAgent
+                    path: vault_agent.hcl
+                  - key: consulTemplate
+                    path: consul_template.hcl
+                  - key: vaultCA
+                    path: vault_ca.pem
+                  - key: ansible
+                    path: vars.yml
+            - name: vault-token
+              emptyDir: {}
+            - name: gcp-service-account
+              emptyDir: {}
+          {{- with .Values.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.affinity }}
+            affinity:
+              {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.tolerations }}
+            tolerations:
+              {{- toYaml . | nindent 12 }}
+          {{- end }}

--- a/consul-backup-gcs/templates/service_account.yaml
+++ b/consul-backup-gcs/templates/service_account.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount }}
+  namespace: {{ .Release.Namespace }}
+  {{- with .Values.labels.serviceAccount }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- if .Values.annotations.serviceAccount }}
+  annotations:
+    {{- with .Values.annotations.serviceAccount }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/consul-backup-gcs/values.yaml
+++ b/consul-backup-gcs/values.yaml
@@ -1,0 +1,77 @@
+# See https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#schedule
+schedule: "0 3 * * *"
+# See https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#concurrency-policy
+concurrencyPolicy: "Allow"
+
+successfulJobsHistoryLimit: "10"
+failedJobsHistoryLimit: "10"
+
+ttlSecondsAfterFinished: 86400
+
+image:
+  repository: basisai/consul-backup-gcs
+  tag: 0.1.0
+  pullPolicy: IfNotPresent
+
+env: {}
+
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount: "consul-backup-gcs"
+
+vault:
+  image: vault
+  tag: 1.0.3
+  pullPolicy: IfNotPresent
+  address: https://vault.service.consul:8200
+  # PEM encoded CA used to issue Vault's Certificate
+  ca: ""
+  auth:
+    path: "kubernetes"
+    role: ""
+  gcp:
+    path: ""
+  env: []
+
+consul:
+  address: consul-server.service.consul:8500
+
+consulTemplate:
+  image: hashicorp/consul-template
+  tag: 0.20.0-light
+  pullPolicy: IfNotPresent
+  env: []
+
+resources:
+  consulTemplate: {}
+  vaultAgent: {}
+  backup:
+    limits:
+      cpu: 200m
+      memory: 256Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+labels:
+  serviceAccount: {}
+  cronJob: {}
+  pods: {}
+  configMap: {}
+
+annotations:
+  serviceAccount: {}
+  cronJob: {}
+  pods: {}
+  configMap: {}
+
+gcs:
+  bucket: ""
+  prefix: "backup/consul/"

--- a/dockerfiles/consul-backup-gcs/Dockerfile
+++ b/dockerfiles/consul-backup-gcs/Dockerfile
@@ -1,0 +1,20 @@
+FROM google/cloud-sdk:251.0.0
+
+ARG ansible_version=2.8.1
+ARG consul_version=1.5.1
+
+RUN set -xe \
+    && apt-get update \
+    && apt-get install -y unzip \
+    && pip install "ansible==${ansible_version}" \
+    && curl -Lo /tmp/consul.zip "https://releases.hashicorp.com/consul/${consul_version}/consul_${consul_version}_linux_amd64.zip" \
+    && unzip -d /usr/local/bin /tmp/consul.zip \
+    && rm /tmp/consul.zip \
+    && ansible --version \
+    && consul version \
+    && gsutil --version
+
+WORKDIR /opt/consul_backup
+COPY ./ ./
+
+CMD ["ansible-playbook", "-i", "localhost," "--connection", "local", "site.yml"]

--- a/dockerfiles/consul-backup-gcs/README.md
+++ b/dockerfiles/consul-backup-gcs/README.md
@@ -1,0 +1,6 @@
+## Docker image for consul-backup-gcs
+
+This Docker image is used in the consul-backup-gcs Helm Chart.
+
+It is built and published to
+[`basisai/consul-backup-gcs`](https://hub.docker.com/r/basisai/consul-backup-gcs).

--- a/dockerfiles/consul-backup-gcs/boto.ini
+++ b/dockerfiles/consul-backup-gcs/boto.ini
@@ -1,0 +1,9 @@
+[Credentials]
+gs_service_key_file = {{ service_account_key }}
+
+[Boto]
+https_validate_certificates = True
+
+[GSUtil]
+content_language = en
+default_api_version = 2

--- a/dockerfiles/consul-backup-gcs/site.yml
+++ b/dockerfiles/consul-backup-gcs/site.yml
@@ -1,0 +1,27 @@
+---
+- name: Backup Consul Snapshot
+  hosts: all
+  vars:
+    # Environment variables to pass to Consul CLI
+    # See https://www.consul.io/docs/commands/index.html#environment-variables
+    consul_environment: {}
+    # Name of gcs bucket
+    gcs_bucket: ""
+    # Object name prefix
+    gcs_prefix: "backup/consul/"
+    # Path to the service account JSON
+    service_account_key: ""
+  tasks:
+    - name: Configure Boto
+      template:
+        dest: "{{ lookup('env','HOME') }}/.boto"
+        src: "{{ playbook_dir }}/boto.ini"
+    - name: Get temporary file to save gcs
+      tempfile:
+        state: file
+      register: snapshot_temp
+    - name: Download Consul Snapshot
+      shell: "consul snapshot save {{ snapshot_temp.path }}"
+      environment: "{{ consul_environment }}"
+    - name: Copy to gcs
+      shell: "gsutil cp -n {{ snapshot_temp.path }} gs://{{ gcs_bucket }}/{{ gcs_prefix }}{{ ansible_date_time.iso8601 }}"


### PR DESCRIPTION
Rationale:
- Keep charts under one roof

Changes:
- Moving the consul-backup-gcs into this charts repo
- Added `dockerfiles` directory to keep any necessary docker files.

Will archive https://github.com/basisai/consul-backup-gcs if this is merged.