### PR TITLE
[WIP] Helm chart to backup Vault data in GCS

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
 
 This repository contains custom Helm charts.
 
-## Telegraf
+- [Consul Backup](consul-backup-gcs/README.md)
+- [Consul ESM](consul-esm/README.md)
+- [Telegraf](telegraf/README.md)
+- [Vault Backup](vault-backup-gcs/README.md)
 
-This chart is based off the stable Telegraf chart with additional Consul Template and Vault agent
-sidecars to allow for better configuration and handling of secrets.
+#### Docker images
+
+In addition, this repository also contains the necessary dockerfiles used by the respective Helm charts. They are located in [dockerfiles/](dockerfiles/).

--- a/dockerfiles/backup-gcs/Dockerfile
+++ b/dockerfiles/backup-gcs/Dockerfile
@@ -1,0 +1,15 @@
+FROM google/cloud-sdk:251.0.0
+
+ARG ansible_version=2.8.1
+
+RUN set -xe \
+    && apt-get update \
+    && apt-get install -y unzip \
+    && pip install "ansible==${ansible_version}" \
+    && ansible --version \
+    && gsutil --version
+
+WORKDIR /opt/backup
+COPY ./ ./
+
+CMD ["ansible-playbook", "-i", "localhost," "--connection", "local", "site.yml"]

--- a/dockerfiles/backup-gcs/README.md
+++ b/dockerfiles/backup-gcs/README.md
@@ -1,0 +1,6 @@
+## Docker image to backup GCS buckets with Ansible
+
+This Docker image is used in the vault-backup-gcs Helm Chart.
+
+It is built and published to
+[`basisai/ansible-backup-gcs`](https://hub.docker.com/r/basisai/ansible-backup-gcs).

--- a/dockerfiles/backup-gcs/boto.ini
+++ b/dockerfiles/backup-gcs/boto.ini
@@ -1,0 +1,9 @@
+[Credentials]
+gs_service_key_file = {{ service_account_key }}
+
+[Boto]
+https_validate_certificates = True
+
+[GSUtil]
+content_language = en
+default_api_version = 2

--- a/dockerfiles/backup-gcs/site.yml
+++ b/dockerfiles/backup-gcs/site.yml
@@ -1,0 +1,19 @@
+---
+- name: Backup GCS
+  hosts: all
+  vars:
+    # Name of gcs source bucket
+    gcs_source_bucket: ""
+    # Name of gcs backup bucket
+    gcs_backup_bucket: ""
+    # Object name prefix
+    gcs_backup_prefix: "backup/"
+    # Path to the service account JSON
+    service_account_key: ""
+  tasks:
+    - name: Configure Boto
+      template:
+        dest: "{{ lookup('env','HOME') }}/.boto"
+        src: "{{ playbook_dir }}/boto.ini"
+    - name: Copy to gcs
+      shell: "gsutil -m cp -r -p gs://{{ gcs_source_bucket }}/* gs://{{ gcs_backup_bucket }}/{{ gcs_backup_prefix }}{{ ansible_date_time.iso8601 }}/"

--- a/vault-backup-gcs/.helmignore
+++ b/vault-backup-gcs/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/vault-backup-gcs/Chart.yaml
+++ b/vault-backup-gcs/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+appVersion: "0.1.0"
+description: Backup Vault to GCS
+name: vault-backup-gcs
+version: 0.1.0
+home: https://github.com/basisai/charts

--- a/vault-backup-gcs/README.md
+++ b/vault-backup-gcs/README.md
@@ -1,0 +1,17 @@
+# Vault Backup
+
+This Helm Chart runs a cron job to backup Vault data stored in a GCS bucket into another GCS bucket.
+
+## Requirements
+
+To use the Helm Chart, you need to have the following:
+
+- A GCS Bucket for backing up to
+- A [Vault](https://www.vaultproject.io/) server setup with a Kubernetes Auth
+Backend for the
+    Kubernetes pod to authenticate with Vault and a GCS Secrets Engine Roleset configured for
+    the pod to retrieve credentials for GCS.
+- A Vault cluster that persists data in a GCS bucket
+
+You can automate most of this using our
+[Terraform Module](https://github.com/basisai/terraform-modules-gcp/blob/master/modules/vault_backup).

--- a/vault-backup-gcs/templates/_helpers.tpl
+++ b/vault-backup-gcs/templates/_helpers.tpl
@@ -1,0 +1,36 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "vault-backup-gcs.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "vault-backup-gcs.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "vault-backup-gcs.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "vaultAddress" -}}
+{{- required "Vault Address" .Values.vault.address -}}
+{{- end -}}

--- a/vault-backup-gcs/templates/config_map.yaml
+++ b/vault-backup-gcs/templates/config_map.yaml
@@ -1,0 +1,71 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "vault-backup-gcs.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "vault-backup-gcs.name" . }}
+    helm.sh/chart: {{ include "vault-backup-gcs.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- with .Values.labels.configMap }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- if .Values.annotations.configMap }}
+  annotations:
+    {{- with .Values.annotations.configMap }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+data:
+  ansible: |
+    gcs_source_bucket: {{ required "GCS vault bucket is required" .Values.gcs.vault_bucket }}
+    gcs_backup_bucket: {{ required "GCS backup bucket is required" .Values.gcs.backup_bucket }}
+    gcs_backup_prefix: {{ .Values.gcs.backup_prefix }}
+    service_account_key: /gcp/service_account.json
+  consulTemplate: |
+    pid_file = "/pid"
+    kill_signal = "SIGTERM"
+
+    vault {
+      vault_agent_token_file = "/vault/token"
+
+      ssl {
+        enabled = true
+      }
+    }
+
+    template {
+      left_delimiter = "||"
+      right_delimiter = "||"
+
+      contents = <<-EOF
+      ||- with secret "{{ required "GCP secrets backend path is needed" .Values.vault.gcp.path }}" -||
+      ||- .Data.private_key_data | base64Decode -||
+      ||- end -||
+      EOF
+
+      destination = "/gcp/service_account.json"
+      create_dest_dirs = true
+      error_on_missing_key = true
+    }
+  vaultCA: {{ required "Vault CA is required" .Values.vault.ca | quote }}
+  vaultAgent: |
+    pid_file = "/pid"
+    exit_after_auth = true
+
+    auto_auth {
+      method "kubernetes" {
+        mount_path = "auth/{{ required "Auth mount path is needed" .Values.vault.auth.path }}"
+
+        config {
+          role = "{{ required "Vault Auth Role is needed" .Values.vault.auth.role }}"
+          token_path = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+        }
+      }
+
+      sink "file" {
+        config {
+          path = "/vault/token"
+        }
+      }
+    }

--- a/vault-backup-gcs/templates/cron_job.yaml
+++ b/vault-backup-gcs/templates/cron_job.yaml
@@ -1,0 +1,171 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ include "vault-backup-gcs.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "vault-backup-gcs.name" . }}
+    helm.sh/chart: {{ include "vault-backup-gcs.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- with .Values.labels.cronJob }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- if .Values.annotations.cronJob }}
+  annotations:
+    {{- with .Values.annotations.cronJob }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  schedule: {{ .Values.schedule }}
+  concurrencyPolicy: {{ .Values.concurrencyPolicy }}
+  successfulJobsHistoryLimit: {{ .Values.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.failedJobsHistoryLimit }}
+  jobTemplate:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "vault-backup-gcs.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- with .Values.labels.cronJob }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/config_map.yaml") . | sha256sum }}
+        {{- with .Values.annotations.cronJob }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      completions: 1
+      parallelism: 1
+      {{- if .Values.ttlSecondsAfterFinished }}
+      ttlSecondsAfterFinished: {{ .Values.ttlSecondsAfterFinished }}
+      {{- end }}
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: {{ include "vault-backup-gcs.name" . }}
+            app.kubernetes.io/instance: {{ .Release.Name }}
+            {{- with .Values.labels.pods }}
+            {{- toYaml . | nindent 10 }}
+            {{- end }}
+          annotations:
+            {{- with .Values.annotations.pods }}
+            {{- toYaml . | nindent 10 }}
+            {{- end }}
+        spec:
+          serviceAccountName: {{ .Values.serviceAccount }}
+          automountServiceAccountToken: true
+          restartPolicy: OnFailure
+          initContainers:
+            - name: vault-agent
+              image: "{{ .Values.vault.image }}:{{ .Values.vault.tag }}"
+              imagePullPolicy: {{ .Values.vault.pullPolicy }}
+              resources:
+                {{- toYaml .Values.resources.vaultAgent | nindent 16 }}
+              volumeMounts:
+                - name: config
+                  mountPath: /config
+                  readOnly: true
+                - name: vault-token
+                  mountPath: /vault
+              env:
+                - name: VAULT_ADDR
+                  value: {{ include "vaultAddress" . | quote }}
+                - name: VAULT_CAPATH
+                  value: /config/vault_ca.pem
+                - name: VAULT_LOG_LEVEL
+                  value: trace
+                {{- if .Values.vault.env }}
+                {{- toYaml .Values.vault.env | nindent 16 }}
+                {{- end }}
+              command:
+                - /bin/vault
+              args:
+                - agent
+                - -config=/config/vault_agent.hcl
+              resources:
+                {{- toYaml .Values.resources.consulTemplate | nindent 16 }}
+            - name: consul-template
+              image: "{{ .Values.consulTemplate.image }}:{{ .Values.consulTemplate.tag }}"
+              imagePullPolicy: {{ .Values.consulTemplate.pullPolicy }}
+              resources:
+                {{- toYaml .Values.resources.consulTemplate | nindent 16 }}
+              volumeMounts:
+                - name: config
+                  mountPath: /config
+                  readOnly: true
+                - name: vault-token
+                  mountPath: /vault
+                  readOnly: true
+                - name: gcp-service-account
+                  mountPath: /gcp
+              env:
+                - name: VAULT_ADDR
+                  value: {{ include "vaultAddress" . | quote }}
+                - name: VAULT_CAPATH
+                  value: /config/vault_ca.pem
+                {{- if .Values.consulTemplate.env }}
+                {{- toYaml .Values.consulTemplate.env | nindent 16 }}
+                {{- end }}
+              command:
+                - "/bin/consul-template"
+              args:
+                - "-once"
+                - "-config=/config/consul_template.hcl"
+                - "-log-level=debug"
+              resources:
+                {{- toYaml .Values.resources.consulTemplate | nindent 16 }}
+          containers:
+            - name: {{ .Chart.Name }}
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              resources:
+                {{- toYaml .Values.resources.backup | nindent 16 }}
+              volumeMounts:
+                - name: gcp-service-account
+                  mountPath: /gcp
+                - name: config
+                  mountPath: /config
+                  readOnly: true
+              env:
+                - name: GOOGLE_CREDENTIALS
+                  value: /gcp/service_account.json
+                {{- if .Values.env }}
+                {{- toYaml .Values.env | nindent 16 }}
+                {{- end }}
+              args:
+                - "ansible-playbook"
+                - '--inventory'
+                - "localhost,"
+                - '--connection=local'
+                - "--extra-vars=@/config/vars.yml"
+                - site.yml
+          volumes:
+            - name: config
+              configMap:
+                name: {{ include "vault-backup-gcs.fullname" . }}
+                items:
+                  - key: vaultAgent
+                    path: vault_agent.hcl
+                  - key: consulTemplate
+                    path: consul_template.hcl
+                  - key: vaultCA
+                    path: vault_ca.pem
+                  - key: ansible
+                    path: vars.yml
+            - name: vault-token
+              emptyDir: {}
+            - name: gcp-service-account
+              emptyDir: {}
+          {{- with .Values.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.affinity }}
+            affinity:
+              {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.tolerations }}
+            tolerations:
+              {{- toYaml . | nindent 12 }}
+          {{- end }}

--- a/vault-backup-gcs/templates/service_account.yaml
+++ b/vault-backup-gcs/templates/service_account.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount }}
+  namespace: {{ .Release.Namespace }}
+  {{- with .Values.labels.serviceAccount }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- if .Values.annotations.serviceAccount }}
+  annotations:
+    {{- with .Values.annotations.serviceAccount }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/vault-backup-gcs/values.yaml
+++ b/vault-backup-gcs/values.yaml
@@ -1,0 +1,74 @@
+# See https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#schedule
+schedule: "0 4 * * *"
+# See https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#concurrency-policy
+concurrencyPolicy: "Allow"
+
+successfulJobsHistoryLimit: "10"
+failedJobsHistoryLimit: "10"
+
+ttlSecondsAfterFinished: 86400
+
+image:
+  repository: basisai/vault-backup-gcs
+  tag: latest
+  pullPolicy: IfNotPresent
+
+env: {}
+
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount: "vault-backup-gcs"
+
+vault:
+  image: vault
+  tag: 1.0.3
+  pullPolicy: IfNotPresent
+  address: https://vault.service.consul:8200
+  # PEM encoded CA used to issue Vault's Certificate
+  ca: ""
+  auth:
+    path: "kubernetes"
+    role: ""
+  gcp:
+    path: ""
+  env: []
+
+consulTemplate:
+  image: hashicorp/consul-template
+  tag: 0.20.0-light
+  pullPolicy: IfNotPresent
+  env: []
+
+resources:
+  consulTemplate: {}
+  vaultAgent: {}
+  backup:
+    limits:
+      cpu: 200m
+      memory: 256Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+labels:
+  serviceAccount: {}
+  cronJob: {}
+  pods: {}
+  configMap: {}
+
+annotations:
+  serviceAccount: {}
+  cronJob: {}
+  pods: {}
+  configMap: {}
+
+gcs:
+  bucket: ""
+  prefix: "backup/vault/"

--- a/vault-backup-gcs/values.yaml
+++ b/vault-backup-gcs/values.yaml
@@ -70,5 +70,6 @@ annotations:
   configMap: {}
 
 gcs:
-  bucket: ""
-  prefix: "backup/vault/"
+  vault_bucket: ""
+  backup_bucket: ""
+  backup_prefix: "backup/vault/"

--- a/vault-backup-gcs/values.yaml
+++ b/vault-backup-gcs/values.yaml
@@ -9,7 +9,7 @@ failedJobsHistoryLimit: "10"
 ttlSecondsAfterFinished: 86400
 
 image:
-  repository: basisai/vault-backup-gcs
+  repository: basisai/ansible-backup-gcs
   tag: latest
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Rationale:
- First step for Vault disaster recovery by backing up vault data stored in GCS bucket

Changes:
- [x] Add general-purpose GCS backup docker image
- [x] Implement vault-backup-gcs Helm chart
- [ ] Test gsutil command
- [ ] Test deployment in staging
