### PR TITLE
Session affinity for CloudSQL proxy deployment

### DIFF
--- a/cloudsql-proxy/Chart.yaml
+++ b/cloudsql-proxy/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "1.16"
 description: Deploy CloudSQL Proxy on Kubernetes
 name: cloudsql-proxy
-version: 0.1.1
+version: 0.2.0
 home: https://github.com/GoogleCloudPlatform/cloudsql-proxy

--- a/cloudsql-proxy/templates/service.yaml
+++ b/cloudsql-proxy/templates/service.yaml
@@ -11,6 +11,10 @@ spec:
       targetPort: {{ .Values.port }}
       protocol: TCP
       name: proxy
+  sessionAffinity: ClientIP
+  sessionAffinityConfig:
+    clientIP:
+      timeoutSeconds: {{ .Values.service.sessionAffinity.timeoutSeconds }}
   selector:
     app.kubernetes.io/name: {{ include "cloudsql-proxy.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/cloudsql-proxy/values.yaml
+++ b/cloudsql-proxy/values.yaml
@@ -53,6 +53,8 @@ port: 5432
 service:
   type: ClusterIP
   port: 5432
+  sessionAffinity:
+    timeoutSeconds: 7200
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
In the case where multiple replicas of proxy pods are running, we should ensure session affinity so clients gets routed to the same proxy pod.