### PR TITLE
Improve Customisation of Ratelimit Chart

### DIFF
--- a/charts/go-ratelimit/Chart.yaml
+++ b/charts/go-ratelimit/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: go-ratelimit
 description: A Ratelimit Service Helm chart for Kubernetes
 type: application
-version: 1.0.3
+version: 1.1.0
 appVersion: v1.4.0
 dependencies:
 - name: "redis-sharded"

--- a/charts/go-ratelimit/templates/configmap.yaml
+++ b/charts/go-ratelimit/templates/configmap.yaml
@@ -5,5 +5,4 @@ metadata:
   labels:
     {{- include "go-ratelimit.labels" . | nindent 4 }}
 data:
-  config.yaml: |-
-    {{ .Values.config | nindent 4 }}
+  {{- toYaml .Values.config | nindent 2}}

--- a/charts/go-ratelimit/templates/deployment.yaml
+++ b/charts/go-ratelimit/templates/deployment.yaml
@@ -11,13 +11,11 @@ spec:
       {{- include "go-ratelimit.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      annotations:
-        checksum/config: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}
       labels:
         {{- include "go-ratelimit.selectorLabels" . | nindent 8 }}
-{{- if .Values.podLabels }}
-{{ toYaml .Values.podLabels | indent 8 }}
-{{- end }}
+        {{- if .Values.podLabels }}
+        {{- toYaml .Values.podLabels | nindent 8 }}
+        {{- end }}
     spec:
       priorityClassName: "{{ .Values.priorityClassName }}"
     {{- with .Values.imagePullSecrets }}
@@ -45,6 +43,13 @@ spec:
             value: "false"
           - name: RUNTIME_IGNOREDOTFILES
             value: "true"
+          # Watch for changes in ConfigMap instead of changes to symlink
+          # See https://github.com/envoyproxy/ratelimit#loading-configuration
+          - name: RUNTIME_WATCH_ROOT
+            value: "false"
+          {{- with .Values.env }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
           name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"

--- a/charts/go-ratelimit/values.yaml
+++ b/charts/go-ratelimit/values.yaml
@@ -41,6 +41,8 @@ hpa:
   minReplicas: 1
   maxReplicas: 5
 
+env: []
+
 resources: {}
 
 nodeSelector: {}
@@ -64,11 +66,12 @@ httpPort: 8080
 
 logLevel: debug
 
-config: |-
-  domain: initconfigmap
-  descriptors:
-    - key: generic_key
-      value: global
+config:
+  example.yaml: |-
+    domain: example
+    descriptors:
+      - key: generic_key
+        value: global
 
 redish:
   enabled: true


### PR DESCRIPTION
- Support additional Env
- Support multiple domain files in ratelimit configuration
- Do not trigger rollout on changes to configuration
- Configure ratelimit to watch for file changes instead of symlink
changes
