### PR TITLE
BDRK-3386: Update fluentd-container-insight to support containerd logs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Order is important; the last matching pattern takes the most
+# precedence.
+# https://help.github.com/en/articles/about-code-owners
+* @basisai/infrastructure

--- a/charts/eks-container-insights/Chart.yaml
+++ b/charts/eks-container-insights/Chart.yaml
@@ -1,6 +1,6 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for EKS Container Insights
 name: eks-container-insights
-version: 0.4.1
+version: 0.4.2
 home: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-setup-logs.html

--- a/charts/eks-container-insights/Chart.yaml
+++ b/charts/eks-container-insights/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for EKS Container Insights
 name: eks-container-insights
-version: 0.4.2
+version: 0.5.0
 home: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-setup-logs.html

--- a/charts/eks-container-insights/templates/configmap.yaml
+++ b/charts/eks-container-insights/templates/configmap.yaml
@@ -25,8 +25,8 @@ data:
       tag *
       read_from_head true
       <parse>
-        @type json
-        time_format %Y-%m-%dT%H:%M:%S.%NZ
+        @type "#{ENV['FLUENT_CONTAINER_TAIL_PARSER_TYPE'] || 'json'}"
+        time_format "#{ENV['FLUENT_CONTAINER_TAIL_PARSER_TIME_FORMAT'] || '%Y-%m-%dT%H:%M:%S.%NZ'}"
       </parse>
     </source>
 
@@ -39,8 +39,8 @@ data:
       tag *
       read_from_head true
       <parse>
-        @type json
-        time_format %Y-%m-%dT%H:%M:%S.%NZ
+        @type "#{ENV['FLUENT_CONTAINER_TAIL_PARSER_TYPE'] || 'json'}"
+        time_format "#{ENV['FLUENT_CONTAINER_TAIL_PARSER_TIME_FORMAT'] || '%Y-%m-%dT%H:%M:%S.%NZ'}"
       </parse>
     </source>
 
@@ -53,8 +53,8 @@ data:
       tag *
       read_from_head true
       <parse>
-        @type json
-        time_format %Y-%m-%dT%H:%M:%S.%NZ
+        @type "#{ENV['FLUENT_CONTAINER_TAIL_PARSER_TYPE'] || 'json'}"
+        time_format "#{ENV['FLUENT_CONTAINER_TAIL_PARSER_TIME_FORMAT'] || '%Y-%m-%dT%H:%M:%S.%NZ'}"
       </parse>
     </source>
 

--- a/charts/eks-container-insights/templates/daemonset.yaml
+++ b/charts/eks-container-insights/templates/daemonset.yaml
@@ -71,6 +71,9 @@ spec:
               value: regional
             # END Archive cluster logs to S3
             {{- end }}
+            {{- with .Values.env }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/charts/eks-container-insights/values.yaml
+++ b/charts/eks-container-insights/values.yaml
@@ -11,7 +11,7 @@ serviceAccount:
   annotations: {}
 
 image: basisai/eks-container-insights
-imageTag: v1.12.4
+imageTag: v1.13.0
 
 initImage: busybox
 initImageTag: 1.32.0
@@ -38,6 +38,13 @@ s3Credentials: |
 additional_container_logs_filters: []
 additional_systemd_logs_filters: []
 additional_host_logs_filters: []
+
+env: []
+  # Use these variables if containerd runtime
+  # - name: FLUENT_CONTAINER_TAIL_PARSER_TYPE
+  #   value: "cri"
+  # - name: FLUENT_CONTAINER_TAIL_PARSER_TIME_FORMAT
+  #   value: "%Y-%m-%dT%H:%M:%S.%N%:z"
 
 resources:
   limits:

--- a/dockerfiles/eks-container-insights/Dockerfile
+++ b/dockerfiles/eks-container-insights/Dockerfile
@@ -1,3 +1,3 @@
-FROM fluent/fluentd-kubernetes-daemonset:v1.13-debian-cloudwatch-amd64-1
+FROM fluent/fluentd-kubernetes-daemonset:v1.13.3-debian-cloudwatch-amd64-1.2
 
 RUN gem install fluent-plugin-s3 -v 1.6.0 --no-document

--- a/dockerfiles/eks-container-insights/Dockerfile
+++ b/dockerfiles/eks-container-insights/Dockerfile
@@ -1,3 +1,3 @@
-FROM fluent/fluentd-kubernetes-daemonset:v1.12.4-debian-cloudwatch-amd64-1.3
+FROM fluent/fluentd-kubernetes-daemonset:v1.13-debian-cloudwatch-amd64-1
 
 RUN gem install fluent-plugin-s3 -v 1.6.0 --no-document

--- a/dockerfiles/fluentd/Dockerfile
+++ b/dockerfiles/fluentd/Dockerfile
@@ -1,5 +1,5 @@
 FROM quay.io/fluentd_elasticsearch/fluentd:v3.2.0
 
-RUN fluent-gem install digest-crc --version 0.5.1 \
-  && fluent-gem install fluent-plugin-gcs --version 0.4.1 \
-  && fluent-gem install fluent-plugin-s3 --version 1.6.0
+RUN fluent-gem install digest-crc --version 0.5.1 --no-document \
+  && fluent-gem install fluent-plugin-gcs --version 0.4.1 --no-document \
+  && fluent-gem install fluent-plugin-s3 --version 1.6.0 --no-document

--- a/tests/ct.yaml
+++ b/tests/ct.yaml
@@ -1,5 +1,5 @@
 validate-maintainers: false
 chart-dirs:
-- /charts
+  - /charts
 chart-repos:
   - jetstack=https://charts.jetstack.io


### PR DESCRIPTION
Reference:
- https://github.com/fluent/fluentd-kubernetes-daemonset/issues/412#issuecomment-756891395
- https://github.com/fluent/fluentd-kubernetes-daemonset/pull/521
- https://github.com/fluent/fluentd-kubernetes-daemonset#use-cri-parser-for-containerdcri-o-logs
- https://github.com/fluent/fluent-plugin-parser-cri